### PR TITLE
Fixes the nav side-bar appearing below wiki content

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -54,6 +54,10 @@
   {
     "matches": ["*://*.endoftheinter.net/search.php*"],
     "js": ["src/js/search.js"]
+  },
+  {
+    "matches": ["*://wiki.endoftheinter.net/*"],
+    "js": ["src/js/wiki.js"]
   }],
 	
   "permissions": [ "tabs", "clipboardWrite", "notifications", "http://*/*", "https://*/*", "contextMenus", "webRequest", "webRequestBlocking", "storage"]

--- a/src/js/wiki.js
+++ b/src/js/wiki.js
@@ -1,0 +1,3 @@
+if(document.getElementsByTagName("style")[1]){
+  document.getElementsByTagName("style")[1].remove();
+}


### PR DESCRIPTION
The navigation side bar is always below the wiki content but shouldn't be. This removes the styling imported from KHTMLFixes.css which allows the wiki to look as intended.
