### PR TITLE
Fix new posts jump link

### DIFF
--- a/options.html
+++ b/options.html
@@ -520,6 +520,13 @@
 									</div>
 									<div class="checkbox">
 										<label>
+											<input type="checkbox" id="fix_new_post_jump" />
+											<span>Fix page jump. Jumps to next page if last seen message was at the end of a page</span>
+										</label>
+
+									</div>
+									<div class="checkbox">
+										<label>
 											<input type="checkbox" id="ignore_keyword" />
 											<span>Ignore topics matching keywords (comma separated list)</span>
 										</label>

--- a/src/js/topicList.js
+++ b/src/js/topicList.js
@@ -453,7 +453,7 @@ var topicList = {
 			}
 		}
 	},
-	callFunctions: function(pm) {
+	applyDomModifications: function(pm) {
 		var grids = document.getElementsByClassName('grid');
 		var functions = this.functions;
 		var config = this.config;
@@ -510,7 +510,7 @@ var topicList = {
 	waitForAsyncContent: function() {
 		// We need to wait for async stuff on page to load before we can call topic list functions						
 		var melonwolfObserver = new MutationObserver(function(mutations) {
-			topicList.callFunctions(topicList.pm);
+			topicList.applyDomModifications(topicList.pm);
 			melonwolfObserver.disconnect();
 		});
 		
@@ -524,7 +524,7 @@ var topicList = {
 		}
 		
 		else {
-			topicList.callFunctions(topicList.pm);
+			topicList.applyDomModifications(topicList.pm);
 		}
 	},
 	
@@ -562,7 +562,7 @@ var topicList = {
 				}
 				
 				else {					
-					topicList.callFunctions(topicList.pm);
+					topicList.applyDomModifications(topicList.pm);
 				}
 				
 			});
@@ -575,7 +575,7 @@ var topicList = {
 			}
 			
 			else {					
-				this.callFunctions(this.pm);
+				this.applyDomModifications(this.pm);
 			}
 		}
 	}

--- a/src/js/topicList.js
+++ b/src/js/topicList.js
@@ -155,6 +155,27 @@ var topicList = {
 				}
 			}
 		},
+		fix_new_post_jump: function(tr) {
+			//Check each topic to see if the last seen post was the end of the page
+			//If it was, change the link to goto the next page
+
+			//dont run on PM page
+			if (window.location.href.includes('inbox.php')) {
+				return;
+			}
+			var msgs = tr.childNodes[2].textContent.split(' ');
+			var msgCount = msgs[0];
+			if ( msgs.length > 1 ) {
+				var newPosts = msgs[1].match(/[0-9]+/)[0];
+				var link = tr.childNodes[2].querySelector('a');
+				var lastSeen = msgCount-newPosts;
+				var topic = link.href.match(/([0-9]+)/)[0];
+				if (lastSeen % 50 === 0) {
+					var newPage = lastSeen/50 + 1;
+					link.href = "//boards.endoftheinter.net/showmessages.php?topic=" + topic +"&page=" +  newPage;
+				}
+			}   
+		},
 		enable_keyword_highlight: function(tr) {
 			var title;
 			var keys = topicList.highlightedKeywords;
@@ -432,7 +453,7 @@ var topicList = {
 			}
 		}
 	},
-	applyDomModifications: function(pm) {
+	callFunctions: function(pm) {
 		var grids = document.getElementsByClassName('grid');
 		var functions = this.functions;
 		var config = this.config;
@@ -448,6 +469,7 @@ var topicList = {
 				}
 				else {
 					for (var k in functions) {
+						
 						if (config[k + pm]) {
 							functions[k](tr, j);
 						}
@@ -488,7 +510,7 @@ var topicList = {
 	waitForAsyncContent: function() {
 		// We need to wait for async stuff on page to load before we can call topic list functions						
 		var melonwolfObserver = new MutationObserver(function(mutations) {
-			topicList.applyDomModifications(topicList.pm);
+			topicList.callFunctions(topicList.pm);
 			melonwolfObserver.disconnect();
 		});
 		
@@ -502,7 +524,7 @@ var topicList = {
 		}
 		
 		else {
-			topicList.applyDomModifications(topicList.pm);
+			topicList.callFunctions(topicList.pm);
 		}
 	},
 	
@@ -540,7 +562,7 @@ var topicList = {
 				}
 				
 				else {					
-					topicList.applyDomModifications(topicList.pm);
+					topicList.callFunctions(topicList.pm);
 				}
 				
 			});
@@ -553,7 +575,7 @@ var topicList = {
 			}
 			
 			else {					
-				this.applyDomModifications(this.pm);
+				this.callFunctions(this.pm);
 			}
 		}
 	}

--- a/src/json/defaultconfig.json
+++ b/src/json/defaultconfig.json
@@ -94,6 +94,7 @@
 	"ignorator_topiclist_pm":false,
 	"userhl_topiclist_pm":false,
 	"page_jump_buttons_pm":true,
+	"fix_new_post_jump":true,
 	"click_expand_thumbnail_pm":true,
 	"user_notes_pm":false,
 	"userhl_messagelist_pm":false,


### PR DESCRIPTION
This should fix the jump link to new posts so that if your most recently viewed post was the last one on a page, it will take you to the next page.