### PR TITLE
Bug fixes + quick edit

### DIFF
--- a/src/js/messageList.js
+++ b/src/js/messageList.js
@@ -3943,6 +3943,9 @@ var messageList = {
             if (messageTop.querySelector('a').href === profileUrl) {
                 let links = new Array(...messageTop.querySelectorAll('a'));
                 let quoteButton = links.filter(a => !!a.innerHTML.match(/^Quote/))[0];
+                if (!quoteButton) {
+                	continue;
+				}
                 let editUrl = quoteButton.href.replace(/quote=/, 'id=');
                 let divider = document.createElement('span');
                 let editLink = document.createElement('a');

--- a/src/js/messageList.js
+++ b/src/js/messageList.js
@@ -3932,13 +3932,40 @@ var messageList = {
 		}
 	},
 
-	/**
+    /**
+	 * Links on your posts to jump right to the Message Edit page
+     */
+    appendQuickEditLinks: function () {
+        let profileUrl = document.querySelector('.userbar a').href;
+
+        for (let messageTop of document.querySelectorAll('.message-top')) {
+            if (messageTop.querySelector('a').href === profileUrl) {
+                let links = new Array(...messageTop.querySelectorAll('a'));
+                let quoteButton = links.filter(a => !!a.innerHTML.match(/^Quote/))[0];
+                let editUrl = quoteButton.href.replace(/quote=/, 'id=');
+                let divider = document.createElement('span');
+                let editLink = document.createElement('a');
+                divider.innerHTML = ' | ';
+                editLink.innerHTML = 'Edit';
+                editLink.href = editUrl;
+                messageTop.insertBefore(editLink, quoteButton);
+                messageTop.insertBefore(divider, quoteButton);
+            }
+        }
+    },
+
+
+    /**
 	 *  The main loop for this script - called after DOMContentLoaded has fired (or immediately if DOM is ready)
 	 *  Applies various types of DOM modifications to the message list, adds listeners for ChromeLL features, etc
 	 */
 	
 	applyDomModifications: function(pm) {
 		this.scrapeTags();
+
+		if (this.config.quick_edit) {
+			this.appendQuickEditLinks();
+		}
 
 		if (this.config.embed_tweets) {
 			this.twitter.injectWidgets();

--- a/src/js/messageList.js
+++ b/src/js/messageList.js
@@ -503,10 +503,12 @@ var messageList = {
 				anchor.href = window.location.href.replace(me, '');
 				anchor.innerHTML = 'Unfilter Me';
 			}
-			
-			var infobar = document.getElementsByClassName('infobar')[0];				
-			infobar.appendChild(divider);
-			infobar.appendChild(anchor);
+
+
+			var infobar = document.getElementsByClassName('infobar')[0];
+            infobar.insertBefore(divider, infobar.lastChild);
+            infobar.insertBefore(anchor, infobar.lastChild);
+
 		},
 		
 		expand_spoilers: function() {
@@ -517,9 +519,9 @@ var messageList = {
 			anchor.id = 'chromell_spoilers';
 			anchor.href = '##';
 			anchor.innerHTML = 'Expand Spoilers';
-			infobar.appendChild(divider);
-			infobar.appendChild(anchor);
-			anchor.addEventListener('click', messageList.spoilers.find);		
+            infobar.insertBefore(divider, infobar.lastChild);
+            infobar.insertBefore(anchor, infobar.lastChild);
+			anchor.addEventListener('click', messageList.spoilers.find);
 		}
 	},
 	
@@ -3929,7 +3931,7 @@ var messageList = {
 			}
 		}
 	},
-	
+
 	/**
 	 *  The main loop for this script - called after DOMContentLoaded has fired (or immediately if DOM is ready)
 	 *  Applies various types of DOM modifications to the message list, adds listeners for ChromeLL features, etc
@@ -3937,7 +3939,7 @@ var messageList = {
 	
 	applyDomModifications: function(pm) {
 		this.scrapeTags();
-		
+
 		if (this.config.embed_tweets) {
 			this.twitter.injectWidgets();
 		}

--- a/src/js/messageList.js
+++ b/src/js/messageList.js
@@ -451,8 +451,9 @@ var messageList = {
 				var divider = document.createTextNode(" | ");
 				anchor.href = '/imagemap.php?' + topicNumber + currentPage;
 				anchor.innerHTML = 'Imagemap';
-				infobar.appendChild(divider);
-				infobar.appendChild(anchor);
+
+                infobar.insertBefore(divider, infobar.lastChild);
+                infobar.insertBefore(anchor, infobar.lastChild);
 			}
 		},
 		

--- a/src/json/defaultconfig.json
+++ b/src/json/defaultconfig.json
@@ -134,5 +134,6 @@
 	"microsoft_sam": true,
 	"seasonal_css": true,
 	"last_clean":0,
-	"last_saved":0
+	"last_saved":0,
+	"quick_edit": true
 }

--- a/src/json/defaultconfig.json
+++ b/src/json/defaultconfig.json
@@ -56,7 +56,7 @@
 	"embed_gfycat":true,
 	"embed_imgur":true,
 	"embed_gfycat_thumbs":false,
-	"embed_tweets":true,
+	"embed_tweets":false,
 	"hide_nws_tweets":true,
 	"hide_tweet_media": false,
 	"dark_tweets": false,


### PR DESCRIPTION
This PR changes all `infobar.appendChild(el)` calls to `infobar.instertBefore(el, infobar.lastChild)` to restore native LiveLinks functionality for displaying the "New Page" banner at the bottom of the page, which depends on the Last Page link being the lastChild of the infobar.

This PR disables Twitter integration by default in the config for two reasons:

1. this was causing pageload issues under certain conditions (i believe may be adblocker related), and
2. the privacy notes mention no data is transmitted but the twitter widgets transmit page view data by default

This PR also adds a new feature: "Quick Edit" links in the message-top of the user's own posts.